### PR TITLE
Stdin comment prompting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    heroku_release (0.1.0)
+    heroku_release (0.1.1)
 
 GEM
   remote: http://rubygems.org/

--- a/spec/heroku_release_spec.rb
+++ b/spec/heroku_release_spec.rb
@@ -13,6 +13,10 @@ describe HerokuRelease do
     it "defaults heroku_remote to heroku" do
       config.heroku_remote.should == "heroku"
     end
+
+    it "defaults prompting for comments to false" do
+      config.prompt_for_comments.should == false
+    end
     
     it "can set heroku_remote" do
       config.heroku_remote = "production"

--- a/spec/task_spec.rb
+++ b/spec/task_spec.rb
@@ -42,6 +42,27 @@ describe HerokuRelease::Task do
 
       @task.tag
     end
+
+    it "prompts for a comment message if enforced" do
+      previous_value = HerokuRelease.config.prompt_for_comments
+      old_stdin = $stdin
+      $stdin = mock('stdin', :gets => "my custom stdin comment")
+
+      begin
+        HerokuRelease.config.prompt_for_comments = true
+        ENV['COMMENT'] = nil
+
+        @task.expects(:get_release_name).returns("release-prompt-123")
+        @task.expects(:commit_version_file).never
+
+        expect_tag_created("release-prompt-123", "my custom stdin comment")
+
+        @task.tag
+      ensure
+        HerokuRelease.config.prompt_for_comments = previous_value
+        $stdin = old_stdin
+      end
+    end
     
     it "commits version file if version_file_path is set" do
       ENV['COMMENT'] = nil


### PR DESCRIPTION
Hey Peter,

I added the ability to enforce a release comment message. If the user sets:

```
config.prompt_for_comments = true
```

If ENV['COMMENTS'] is missing, they will see a `STDIN` prompt asking them to supply a comment message. This is an optional feature for the user of this lib to turn on, but I think this would help me/others a lot. I will forget the `COMMENTS` env variable about 80% of the time ;)
